### PR TITLE
Add ghg_input=0 to namelists with non-compatible radiation options

### DIFF
--- a/Namelists/weekly/em_real/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_real/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.08
+++ b/Namelists/weekly/em_real/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.09
+++ b/Namelists/weekly/em_real/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input   			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_real/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.10
+++ b/Namelists/weekly/em_real/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.11
+++ b/Namelists/weekly/em_real/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.15
+++ b/Namelists/weekly/em_real/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.16
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.18
+++ b/Namelists/weekly/em_real/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.19
+++ b/Namelists/weekly/em_real/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_real/MPI/namelist.input.20
+++ b/Namelists/weekly/em_real/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.29
+++ b/Namelists/weekly/em_real/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_real/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_real/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_real/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.39
+++ b/Namelists/weekly/em_real/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.42
+++ b/Namelists/weekly/em_real/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.63
+++ b/Namelists/weekly/em_real/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.fail_comparison
+++ b/Namelists/weekly/em_real/MPI/namelist.input.fail_comparison
@@ -76,6 +76,7 @@
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
  icloud                              = 3,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.fail_test
+++ b/Namelists/weekly/em_real/MPI/namelist.input.fail_test
@@ -85,6 +85,7 @@
  num_land_cat                        = 24,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input		   	     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_real/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_real/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_real/UNUSED/namelist.input.23
@@ -80,6 +80,7 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
+ ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.07
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.07
@@ -82,6 +82,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.16
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.18
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.38
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.38
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realA/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realA/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realA/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realA/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realB/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realB/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realB/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realB/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realC/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realC/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realC/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realC/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realD/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realD/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realD/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realD/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realE/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realE/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realE/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realE/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realF/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realF/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realF/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realF/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.65DF
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.65DF
@@ -81,6 +81,7 @@
  mp_zero_out                         = 0,
  aer_opt                             = 3,
  use_aero_icbc                       = .FALSE.
+ ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realG/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realG/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realG/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realG/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realH/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realH/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realH/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realH/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realI/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realI/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realI/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realI/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realJ/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realK/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realK/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realK/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realK/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realL/FAIL/namelist.input.47
@@ -79,6 +79,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.07NE
@@ -87,6 +87,7 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.08
@@ -78,6 +78,7 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.09
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.09QT
@@ -79,6 +79,7 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.10
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.11
@@ -79,6 +79,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.15
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.15AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.16
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.16BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.16DF
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.18
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.18BN
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.19
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realL/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.20
@@ -82,6 +82,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.20NE
@@ -87,6 +87,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.29
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realL/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.29QT
@@ -83,6 +83,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realL/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.38AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.39
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.39AD
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.42
@@ -78,6 +78,7 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.63
@@ -90,6 +90,7 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
+ ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.kiaps1NE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.kiaps2
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.rala
@@ -80,6 +80,7 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.ralbNE
@@ -81,6 +81,7 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.urb3aNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.urb3bNE
@@ -94,6 +94,7 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
+ ghg_input                           = 0
  /
 
  &fdda

--- a/rd_l2_norm.py
+++ b/rd_l2_norm.py
@@ -2,6 +2,10 @@ from netCDF4 import Dataset
 import numpy as np
 import sys
 
+# override boolean warning
+from warnings import filterwarnings
+filterwarnings(action='ignore', category=DeprecationWarning, message='`np.bool` is a deprecated alias')
+
 o = Dataset(str(sys.argv[1]))
 
 list_of_vars = o.variables.keys()

--- a/script.csh
+++ b/script.csh
@@ -22,7 +22,7 @@ if      ( $WHICH_FUNCTION == BUILD ) then
 
 	#	There are at least four args that are required for a BUILD step.
 	#	1. Clean? If yes then the value is CLEAN, if no then any other string.
-	#	2. The configuration number. For example, Linux GNU MPI = 34.
+	#	2. The configuration number. For example, Linux GNU MPI = 3.
 	#	3. The nest option for the configuration. Always 1, unless a moving domain.
 	#	4. The build target for compile, for example, "em_real".
 
@@ -105,7 +105,7 @@ if      ( $WHICH_FUNCTION == BUILD ) then
 	
 	#	The configure step has three pieces of input information. 
 	#	1. There are the associated option flags, for example "-d".
-	#	2. There is the numerical selection, for example Linux GNU MPI = 34.
+	#	2. There is the numerical selection, for example Linux GNU MPI = 3.
 	#	3. There is the nesting, typically = 1.
 
 	./configure ${CONF_OPT} << EOF >& configure.output
@@ -181,7 +181,7 @@ else if ( $WHICH_FUNCTION == RUN   ) then
 
 	#	We need four input values for the RUN phase of the script.
 	#	1. The build target, for example "em_real".
-	#	2. The build number from the configuration, such as 34 for MPI.
+	#	2. The build number from the configuration, such as 3 for MPI.
 	#	   Honestly, this should be cleaned up by getting the info
 	#	   from within files in the container.
 	#	3. The directory structure where the namelist and data are located
@@ -316,11 +316,11 @@ else if ( $WHICH_FUNCTION == RUN   ) then
 	          ( ( ${COMP_BUILD_TARGET} == em_real       ) && ( $COMP_RUN_DIR == em_realJ       ) ) || \
 	          ( ( ${COMP_BUILD_TARGET} == em_real       ) && ( $COMP_RUN_DIR == em_realK       ) ) || \
 	          ( ( ${COMP_BUILD_TARGET} == em_real       ) && ( $COMP_RUN_DIR == em_realL       ) ) ) then
-		if      ( $CONF_BUILD_NUM == 32 ) then
+		if      ( $CONF_BUILD_NUM == 1 ) then
 			cp /wrf/Namelists/weekly/$COMP_RUN_DIR/SERIAL/namelist.input.${COMP_RUN_TEST} namelist.input
-		else if ( $CONF_BUILD_NUM == 33 ) then
+		else if ( $CONF_BUILD_NUM == 2 ) then
 			cp /wrf/Namelists/weekly/$COMP_RUN_DIR/OPENMP/namelist.input.${COMP_RUN_TEST} namelist.input
-		else if ( $CONF_BUILD_NUM == 34 ) then
+		else if ( $CONF_BUILD_NUM == 3 ) then
 			cp /wrf/Namelists/weekly/$COMP_RUN_DIR/MPI/namelist.input.${COMP_RUN_TEST} namelist.input
 		endif
 	else if ( ( ${COMP_BUILD_TARGET} == em_real ) && ( $COMP_RUN_DIR == em_move ) ) then
@@ -357,16 +357,16 @@ else if ( $WHICH_FUNCTION == RUN   ) then
 
 	#	Run the front-end program to WRF, which is real.exe, real_nmm.exe, or ideal.exe.
 
-	if      ( $CONF_BUILD_NUM == 32 ) then
+	if      ( $CONF_BUILD_NUM == 1 ) then
 		${exec} >& real.print.out
 		grep -q SUCCESS real.print.out
 		set OK_FOUND_SUCCESS = $status
-	else if ( $CONF_BUILD_NUM == 33 ) then
+	else if ( $CONF_BUILD_NUM == 2 ) then
 		setenv OMP_NUM_THREADS 1
 		${exec} >& real.print.out
 		grep -q SUCCESS real.print.out
 		set OK_FOUND_SUCCESS = $status
-	else if ( $CONF_BUILD_NUM == 34 ) then
+	else if ( $CONF_BUILD_NUM == 3 ) then
 		mpirun -np $NP --oversubscribe ${exec} >& real.print.out
 		cat rsl.out.0000 >> real.print.out
 		grep -q SUCCESS rsl.out.0000
@@ -423,18 +423,18 @@ else if ( $WHICH_FUNCTION == RUN   ) then
 
 #DAVE
 #	if ( -e /wrf/wrfoutput/SUCCESS_RUN_REAL_${COMP_BUILD_TARGET}_${CONF_BUILD_NUM}_${COMP_RUN_DIR}_${COMP_RUN_TEST} ) then
-		if      ( $CONF_BUILD_NUM == 32 ) then
+		if      ( $CONF_BUILD_NUM == 1 ) then
 			wrf.exe >& wrf.print.out
 			grep -q SUCCESS wrf.print.out
 			set OK_FOUND_SUCCESS = $status
-		else if ( $CONF_BUILD_NUM == 33 ) then
+		else if ( $CONF_BUILD_NUM == 2 ) then
 			if ( $HAVE_THREADS == TRUE ) then
 				setenv OMP_NUM_THREADS $WANT_THREADS
 			endif
 			wrf.exe >& wrf.print.out
 			grep -q SUCCESS wrf.print.out
 			set OK_FOUND_SUCCESS = $status
-		else if ( $CONF_BUILD_NUM == 34 ) then
+		else if ( $CONF_BUILD_NUM == 3 ) then
 			mpirun -np 3 --oversubscribe wrf.exe >& wrf.print.out
 			cat rsl.out.0000 >> wrf.print.out
 			grep -q SUCCESS rsl.out.0000
@@ -480,7 +480,7 @@ else if ( $WHICH_FUNCTION == RUN   ) then
 				if ( ( $OK_nan == 1 ) && ( $OK_time_levels == 0 ) ) then
 					set FILE = /wrf/wrfoutput/SUCCESS_RUN_WRF_d0${d}_${COMP_BUILD_TARGET}_${CONF_BUILD_NUM}_${COMP_RUN_DIR}_${COMP_RUN_TEST}
 					touch $FILE
-					python3 ~/rd_l2_norm.py wrfout_d0${d}_* >> $FILE
+					python3.8 ~/rd_l2_norm.py wrfout_d0${d}_* >> $FILE
 					exit ( 0 )
 				else 
 					touch /wrf/wrfoutput/FAIL_RUN_WRF_d0${d}_${COMP_BUILD_TARGET}_${CONF_BUILD_NUM}_${COMP_RUN_DIR}_${COMP_RUN_TEST}


### PR DESCRIPTION
By default, ghg_input is turned on. This is only compatible with radiation options: CAM, RRTM, Dudhia, RRTMG, and RRTMG fast. There are several namelists in the regression tests that use other options and therefore the model is not able to run for those tests. All namelists that include non-compatible radiation options now include ghg_input=0 in the &physics record.