### PR TITLE
Revert "add ghg_input=0 to namelists w/ non-compatible radiation,"

### DIFF
--- a/Namelists/weekly/em_real/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_real/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.08
+++ b/Namelists/weekly/em_real/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.09
+++ b/Namelists/weekly/em_real/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input   			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_real/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.10
+++ b/Namelists/weekly/em_real/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.11
+++ b/Namelists/weekly/em_real/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.15
+++ b/Namelists/weekly/em_real/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.16
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.18
+++ b/Namelists/weekly/em_real/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.19
+++ b/Namelists/weekly/em_real/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_real/MPI/namelist.input.20
+++ b/Namelists/weekly/em_real/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.29
+++ b/Namelists/weekly/em_real/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_real/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_real/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_real/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.39
+++ b/Namelists/weekly/em_real/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.42
+++ b/Namelists/weekly/em_real/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.63
+++ b/Namelists/weekly/em_real/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.fail_comparison
+++ b/Namelists/weekly/em_real/MPI/namelist.input.fail_comparison
@@ -76,7 +76,6 @@
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
  icloud                              = 3,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.fail_test
+++ b/Namelists/weekly/em_real/MPI/namelist.input.fail_test
@@ -85,7 +85,6 @@
  num_land_cat                        = 24,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input		   	     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_real/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_real/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_real/UNUSED/namelist.input.23
@@ -80,7 +80,6 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
- ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.07
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.07
@@ -82,7 +82,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.16
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.18
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/MPI/namelist.input.38
+++ b/Namelists/weekly/em_real8/MPI/namelist.input.38
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realA/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realA/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realA/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realA/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realA/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realB/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realB/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realB/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realB/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realB/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realC/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realC/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realC/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realC/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realC/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realD/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realD/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realD/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realD/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realD/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realE/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realE/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realE/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realE/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realE/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realF/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realF/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realF/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realF/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.65DF
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.65DF
@@ -81,7 +81,6 @@
  mp_zero_out                         = 0,
  aer_opt                             = 3,
  use_aero_icbc                       = .FALSE.
- ghg_input			     = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realG/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realG/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realG/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realG/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realG/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realG/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realH/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realH/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realH/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realH/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realH/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realH/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realI/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realI/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realI/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realI/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realI/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realI/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realJ/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realJ/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realJ/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realK/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realK/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realK/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realK/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realK/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realK/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/FAIL/namelist.input.47
+++ b/Namelists/weekly/em_realL/FAIL/namelist.input.47
@@ -79,7 +79,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  use_aero_icbc                       = .TRUE.
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.07NE
@@ -87,7 +87,6 @@
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
  sf_urban_physics                    = 2,     2,     2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.08
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.08
@@ -78,7 +78,6 @@
  num_soil_layers                     = 6,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.09
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.09
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.09QT
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.09QT
@@ -79,7 +79,6 @@
  num_soil_layers                     = 6,
  mp_zero_out                         = 0,
  num_land_cat                        = 21,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.10
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.10
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.11
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.11
@@ -79,7 +79,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.15
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.15
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.15AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.16
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.16
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.16BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.16DF
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.18
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.18
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.18BN
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.19
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.19
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realL/MPI/namelist.input.20
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.20
@@ -82,7 +82,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.20NE
@@ -87,7 +87,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.29
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.29
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realL/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.29QT
@@ -83,7 +83,6 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
- ghg_input                           = 0
  /
 
 

--- a/Namelists/weekly/em_realL/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.38AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.39
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.39
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.39AD
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 28,
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.42
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.42
@@ -78,7 +78,6 @@
  num_soil_layers                     = 2,
  num_land_cat                        = 24
  mp_zero_out                         = 0,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.63
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.63
@@ -90,7 +90,6 @@
  maxens3                             = 16,
  ensdim                              = 144,
  fractional_seaice                   = 1, 
- ghg_input                           = 0
  /
 
 &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.kiaps1NE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.kiaps1NE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.kiaps2
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.kiaps2
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.rala
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.rala
@@ -80,7 +80,6 @@
  ensdim                              = 144,
  icloud                              = 3,
  num_land_cat                        = 28
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.ralbNE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.ralbNE
@@ -81,7 +81,6 @@
  icloud                              = 3,
  num_land_cat                        = 28
  swint_opt                           = 2,
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.urb3aNE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.urb3aNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realL/MPI/namelist.input.urb3bNE
+++ b/Namelists/weekly/em_realL/MPI/namelist.input.urb3bNE
@@ -94,7 +94,6 @@
  aer_ssa_val                         = 0.85
  aer_asy_opt                         = 1,
  aer_asy_val                         = 0.90
- ghg_input                           = 0
  /
 
  &fdda


### PR DESCRIPTION
This commit #1 was causing regtest failures. Reverting for now.

This reverts commit 2cb7e4251e2f384ed5a7e86f76247f0714d8a698.