### PR TITLE
added ghg_input=0 to namelists with no radiation

### DIFF
--- a/Namelists/weekly/em_b_wave/namelist.input.1
+++ b/Namelists/weekly/em_b_wave/namelist.input.1
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.1NE
+++ b/Namelists/weekly/em_b_wave/namelist.input.1NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.2
+++ b/Namelists/weekly/em_b_wave/namelist.input.2
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.2NE
+++ b/Namelists/weekly/em_b_wave/namelist.input.2NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.3
+++ b/Namelists/weekly/em_b_wave/namelist.input.3
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.3NE
+++ b/Namelists/weekly/em_b_wave/namelist.input.3NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.4
+++ b/Namelists/weekly/em_b_wave/namelist.input.4
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.5
+++ b/Namelists/weekly/em_b_wave/namelist.input.5
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_b_wave/namelist.input.5NE
+++ b/Namelists/weekly/em_b_wave/namelist.input.5NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_fire/namelist.input.01
+++ b/Namelists/weekly/em_fire/namelist.input.01
@@ -67,6 +67,7 @@
  icloud                              = 0,
  num_soil_layers                     = 5,
  mp_zero_out                         = 0,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_hill2d_x/namelist.input.01
+++ b/Namelists/weekly/em_hill2d_x/namelist.input.01
@@ -54,6 +54,7 @@
  cu_physics                          = 0,
  cudt                                = 0,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_move/MPI/namelist.input.01
+++ b/Namelists/weekly/em_move/MPI/namelist.input.01
@@ -80,6 +80,7 @@
  oml_hml0                            = -50,
  oml_gamma                           = 0.20,
  isftcflx                            = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_move/MPI/namelist.input.02
+++ b/Namelists/weekly/em_move/MPI/namelist.input.02
@@ -82,6 +82,7 @@
  oml_hml0                            = -50,
  oml_gamma                           = 0.20,
  isftcflx                            = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/MPI/namelist.input.01
+++ b/Namelists/weekly/em_quarter_ss/MPI/namelist.input.01
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/MPI/namelist.input.01NE
+++ b/Namelists/weekly/em_quarter_ss/MPI/namelist.input.01NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/MPI/namelist.input.07
+++ b/Namelists/weekly/em_quarter_ss/MPI/namelist.input.07
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_quarter_ss/MPI/namelist.input.07NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.02
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.02
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.02NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.02NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.03
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.03
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.03NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.03NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.04
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.04
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.04NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.04NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.05
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.05
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.05NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.05NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.06
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.06
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.06NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.06NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.08
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.08
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.09
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.09
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.10
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.10
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.11NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.11NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.12NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.12NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.13NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.13NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss/namelist.input.14NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.14NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.02NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.02NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.03
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.03
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.03NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.03NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.04
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.04
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.04NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.04NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.05
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.05
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.05NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.05NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.06
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.06
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.06NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.06NE
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.08
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.08
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.10
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.10
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.11NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.11NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.12NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.12NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.13NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.13NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.14NE
+++ b/Namelists/weekly/em_quarter_ss8/HOLD/namelist.input.14NE
@@ -63,6 +63,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.02
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.02
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.03
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.03
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.04
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.04
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.05
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.05
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.06
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.06
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.08
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.08
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.09
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.09
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.10
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.10
@@ -62,6 +62,7 @@
  cu_physics                          = 0,     0,     0,
  cudt                                = 5,     5,     5,
  num_soil_layers                     = 5,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_real/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_real8/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_real8/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_real8/UNUSED/namelist.input.23
@@ -80,6 +80,7 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_realA/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realA/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_realA/UNUSED/namelist.input.23
@@ -80,6 +80,7 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_realB/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realB/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_realB/UNUSED/namelist.input.23
@@ -80,6 +80,7 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_realC/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realC/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_realC/UNUSED/namelist.input.23
@@ -80,6 +80,7 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_realD/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realD/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_realD/UNUSED/namelist.input.23
@@ -80,6 +80,7 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_realE/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realE/UNUSED/namelist.input.23
+++ b/Namelists/weekly/em_realE/UNUSED/namelist.input.23
@@ -80,6 +80,7 @@
  tot_backscat_t                      = 1.0E-6, 1.0E-6, 1.0E-6
  tot_backscat_psi                    = 1.0E-5, 1.0E-5, 1.0E-5
  nens                                = 1,
+ ghg_input                           = 0
  /
 
  &fdda

--- a/Namelists/weekly/em_realF/UNUSED/namelist.input.18
+++ b/Namelists/weekly/em_realF/UNUSED/namelist.input.18
@@ -80,6 +80,7 @@
  maxens2                             = 3,
  maxens3                             = 16,
  ensdim                              = 144,
+ ghg_input                           = 0
  /
 
  &fdda


### PR DESCRIPTION
Following the reasoning from the previous commit, now ghg_input = 0 is added to all namelists that use no radiation (ra_lw/sw_physics = 0). 